### PR TITLE
Configure MNE raw browser to use full notebook width

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,5 +68,8 @@ RUN git clone --depth=1 https://github.com/mne-tools/mne-tools.github.io && \
     mv mne-tools.github.io/dev/_downloads/*.ipynb . && \
     rm -Rf mne-tools.github.io
 
+# Configure the MNE raw browser window to use the full width of the notebook
+RUN ipython -c "import mne; mne.set_config('MNE_BROWSE_RAW_SIZE', '9.8, 7')"
+
 # Add an x-server to the entrypoint. This is needed by Mayavi
 ENTRYPOINT ["tini", "-g", "--", "xvfb-run"]


### PR DESCRIPTION
Tweaks the MNE config to have the raw plotting window be nicely sized for notebooks. Works super nice with `%matplotlib notebook`.