### PR TITLE
Change MNE pip path and where to find notebooks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN pip install vtk && \
     pip install scipy && \
     pip install xvfbwrapper && \
     pip install https://github.com/nipy/PySurfer/archive/master.zip && \
-    pip install https://github.com/mne-tools/mne/archive/master.zip
+    pip install https://codeload.github.com/mne-tools/mne-python/zip/master
 
 # Install Jupyter notebook extensions
 RUN pip install RISE && \
@@ -65,7 +65,7 @@ RUN ipython -c "import matplotlib.pyplot as plt; print(plt)"
 
 # Download and move ipynb notebooks
 RUN git clone --depth=1 https://github.com/mne-tools/mne-tools.github.io && \
-    mv mne-tools.github.io/dev/_downloads/*.ipynb . && \
+    mv mne-tools.github.io/dev/_downloads/*/*.ipynb . && \
     rm -Rf mne-tools.github.io
 
 # Configure the MNE raw browser window to use the full width of the notebook


### PR DESCRIPTION
Binder would not launch with the previous pip install command.

And the location of notebooks seems to have moved. So I now copy all notebooks one directory deep.