### PR TITLE
Deprecate MNE-Binder in favour of MNE-Docker

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,8 @@
 .. -*- mode: rst -*-
 
+THIS PACKAGE HAS BEEN DEPRECATED. PLEASE USE `MNE-Docker <https://github.com/mne-tools/mne-docker>`_ 
+=====================================================================================================
+
 mne-binder
 ==========
 


### PR DESCRIPTION
As discussed in #9 
All efforts are now focused on MNE-Docker and this works well with Binder